### PR TITLE
Set params as `undefined` by default

### DIFF
--- a/src/Cypher.js
+++ b/src/Cypher.js
@@ -32,7 +32,7 @@ class Cypher extends Component {
     clearInterval(this.interval);
   }
   query(props) {
-    const { query, params = null } = props;
+    const { query, params = undefined } = props;
     if (!query) throw new Error(missingQueryError);
     if (!this.driver) throw new Error(missingDriverError);
     this.setState({ pending: true }, () => {

--- a/src/Cypher.test.js
+++ b/src/Cypher.test.js
@@ -71,7 +71,7 @@ it("runs cypher query on mount and not on new props", () => {
   );
 
   // Then
-  expect(spy).toHaveBeenLastCalledWith(query, null);
+  expect(spy).toHaveBeenLastCalledWith(query, undefined);
   expect(spy).toHaveBeenCalledTimes(1);
 
   // When
@@ -82,7 +82,7 @@ it("runs cypher query on mount and not on new props", () => {
   );
 
   // Then
-  expect(spy).toHaveBeenLastCalledWith(query, null);
+  expect(spy).toHaveBeenLastCalledWith(query, undefined);
   expect(spy).toHaveBeenCalledTimes(1);
 });
 
@@ -105,21 +105,21 @@ it("runs cypher query at an interval", () => {
   );
 
   // Then
-  expect(spy).toHaveBeenLastCalledWith(query, null);
+  expect(spy).toHaveBeenLastCalledWith(query, undefined);
   expect(spy).toHaveBeenCalledTimes(1);
 
   // When
   jest.runOnlyPendingTimers();
 
   // Then
-  expect(spy).toHaveBeenLastCalledWith(query, null);
+  expect(spy).toHaveBeenLastCalledWith(query, undefined);
   expect(spy).toHaveBeenCalledTimes(2);
 
   // When
   jest.runOnlyPendingTimers();
 
   // Then
-  expect(spy).toHaveBeenLastCalledWith(query, null);
+  expect(spy).toHaveBeenLastCalledWith(query, undefined);
   expect(spy).toHaveBeenCalledTimes(3);
 });
 
@@ -144,7 +144,7 @@ it("passes result argument to render function", () => {
 
   // Then
   let tree = r.toJSON();
-  expect(runSpy).toHaveBeenLastCalledWith(query, null);
+  expect(runSpy).toHaveBeenLastCalledWith(query, undefined);
   expect(runSpy).toHaveBeenCalledTimes(1);
   expect(closeSpy).toHaveBeenCalledTimes(0);
   expect(renderSpy).toHaveBeenLastCalledWith({
@@ -192,7 +192,7 @@ it("passes error argument to render function", () => {
 
   // Then
   let tree = r.toJSON();
-  expect(runSpy).toHaveBeenLastCalledWith(query, null);
+  expect(runSpy).toHaveBeenLastCalledWith(query, undefined);
   expect(runSpy).toHaveBeenCalledTimes(1);
   expect(closeSpy).toHaveBeenCalledTimes(0);
   expect(renderSpy).toHaveBeenCalledTimes(2); // Initial render + pending


### PR DESCRIPTION
This is because the `run` function in the neo4j driver returns an error when set as `null`